### PR TITLE
Powercli help needs less command installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ skip_if_unavailable=True\n '\
 WORKDIR /powershell
 
 # Install PowerShell on Photon 
-RUN tdnf install -y unzip powershell curl openssl
+RUN tdnf install -y unzip powershell curl openssl less
 
 # Download and Unzip the PowerCLI module to the users module directory
 ADD https://download3.vmware.com/software/vmw-tools/powerclicore/PowerCLI_Core.zip /powershell


### PR DESCRIPTION
PowerCLI uses 'less' command to display help. The current container shows this error:
```
PS /powershell> help Get-VM
Get-Command : The term 'less' is not recognized as the name of a cmdlet, function, script file, or operable program. Che
ck the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:16 char:21
+     $moreCommand = (Get-Command -CommandType Application less | Selec ...
```

This one line change adds less command to the container.