### PR TITLE
Pin powervRA to 2.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN cp /powershell/powernsx-master/PowerNSX.ps*1 ~/.local/share/powershell/Modul
 
 # Add PowervRA 
 RUN powershell -Command 'Set-PSRepository -Name PSGallery -InstallationPolicy Trusted'
-RUN powershell -Command 'Install-Module -Name PowervRA -Confirm:$false'
+RUN powershell -Command 'Install-Module -Name PowervRA -Confirm:$false -RequiredVersion 2.1.0'
 
 # Add the PowerCLI Example Scripts and Modules
 RUN git clone https://github.com/vmware/PowerCLI-Example-Scripts


### PR DESCRIPTION
powervRA updated to 2.2.0, and does not install properly:
```
PackageManagement\Install-Package : Package 'PowervRA' failed to be installed because: /tmp/1872588994/PowervRA/PowervRA.nuspec
At /opt/microsoft/powershell/6.0.0-alpha.18/Modules/PowerShellGet/1.1.2.0/PSModule.psm1:2089 char:20
+ ...           $sid = PackageManagement\Install-Package @PSBoundParameters
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidResult: (PowervRA:String) [Install-Package], Exception
    + FullyQualifiedErrorId : Package '{0}' failed to be installed because: {1},Microsoft.PowerShell.PackageManagement.Cmdlets.InstallPackage
```

This commit pins powervRA to 2.1.0.

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>