### PR TITLE
Reduce docker layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,52 +8,50 @@ ARG POWERCLI_PACKAGE=PowerCLI.ViCore.zip
 ARG POWERCLI_VDS_PACKAGE=PowerCLI.Vds.zip
 ARG POWERCLI_CIS_PACKAGE=PowerCLI.Cis.zip
 
-# Add PowerShell repository location to Photon OS
-RUN echo $'[powershell]\n\
-
-name=VMware Photon Linux 1.0(x86_64)\n\
-baseurl=https://vmware.bintray.com/powershell\n\
-gpgcheck=0\n\
-enabled=1\n\
-skip_if_unavailable=True\n '\
->> /etc/yum.repos.d/powershell.repo
-
 # Set the working directory 
 WORKDIR /powershell
 
-# Install PowerShell on Photon 
-RUN tdnf install -y unzip powershell curl openssl less git
-
 # Download and Unzip the PowerCLI module to the users module directory
 ADD https://download3.vmware.com/software/vmw-tools/powerclicore/PowerCLI_Core.zip /powershell
-RUN unzip /powershell/PowerCLI_Core.zip -d /powershell
-RUN mkdir -p /root/.config/powershell/
-RUN mkdir -p ~/.local/share/powershell/Modules
-RUN unzip /powershell/$POWERCLI_PACKAGE -d ~/.local/share/powershell/Modules
-RUN unzip /powershell/$POWERCLI_VDS_PACKAGE -d ~/.local/share/powershell/Modules
-RUN unzip /powershell/$POWERCLI_CIS_PACKAGE -d ~/.local/share/powershell/Modules
-
-# Change the default PowerShell profile to include PowerCLI startup
-RUN mv /powershell/Start-PowerCLI.ps1 /root/.config/powershell/Microsoft.PowerShell_profile.ps1
-
 # Add PowerNSX
 ADD https://github.com/vmware/powernsx/archive/master.zip /powershell
-RUN mkdir ~/.local/share/powershell/Modules/PowerNSX
-RUN unzip /powershell/master.zip -d /powershell/
-RUN cp /powershell/powernsx-master/PowerNSX.ps*1 ~/.local/share/powershell/Modules/PowerNSX/
 
-# Add PowervRA 
-RUN powershell -Command 'Set-PSRepository -Name PSGallery -InstallationPolicy Trusted'
-RUN powershell -Command 'Install-Module -Name PowervRA -Confirm:$false'
+# Add PowerShell repository location to Photon OS
+COPY powershell.repo /etc/yum.repos.d
 
-# Add the PowerCLI Example Scripts and Modules
-RUN git clone https://github.com/vmware/PowerCLI-Example-Scripts
+	# Install PowerShell on Photon 
+RUN tdnf install -y unzip powershell less git \
+	&& tdnf clean all \
+	&& unzip /powershell/PowerCLI_Core.zip -d /powershell \
+	&& mkdir -p /root/.config/powershell/ \
+	&& mkdir -p ~/.local/share/powershell/Modules \
+	&& unzip /powershell/$POWERCLI_PACKAGE -d ~/.local/share/powershell/Modules \
+	&& unzip /powershell/$POWERCLI_VDS_PACKAGE -d ~/.local/share/powershell/Modules \
+	&& unzip /powershell/$POWERCLI_CIS_PACKAGE -d ~/.local/share/powershell/Modules \
+	&& rm -rf /powershell/PowerCLI_Core.zip \
+	&& rm -rf /powershell/$POWERCLI_PACKAGE \
+	&& rm -rf /powershell/$POWERCLI_VDS_PACKAGE \
+	&& rm -rf /powershell/$POWERCLI_CIS_PACKAGE \
 
-# Add modules from PowerCLI-Example-Scripts folder to correct places
-RUN mv /powershell/PowerCLI-Example-Scripts/Modules/VMware.VMEncryption ~/.local/share/powershell/Modules/
-RUN mv /powershell/PowerCLI-Example-Scripts/Modules/VMFSIncrease ~/.local/share/powershell/Modules/
-RUN mv /powershell/PowerCLI-Example-Scripts/Modules/Vi-Module ~/.local/share/powershell/Modules/
-RUN chmod +x /powershell/PowerCLI-Example-Scripts/Scripts/modules.sh
-RUN /powershell/PowerCLI-Example-Scripts/Scripts/modules.sh
+	# Change the default PowerShell profile to include PowerCLI startup
+	&& mv /powershell/Start-PowerCLI.ps1 /root/.config/powershell/Microsoft.PowerShell_profile.ps1 \
+	&& mkdir ~/.local/share/powershell/Modules/PowerNSX \
+	&& unzip /powershell/master.zip -d /powershell/ \
+	&& rm -fr /powershell/master.zip \
+	&& cp /powershell/powernsx-master/module/platform/core/PowerNSX/PowerNSX.ps*1 ~/.local/share/powershell/Modules/PowerNSX/ \
+	
+	# Add PowervRA 
+	&& powershell -Command 'Set-PSRepository -Name PSGallery -InstallationPolicy Trusted' \
+	&& powershell -Command 'Install-Module -Name PowervRA -Confirm:$false' \
+
+	# Add the PowerCLI Example Scripts and Modules
+	&& git clone https://github.com/vmware/PowerCLI-Example-Scripts \
+
+	# Add modules from PowerCLI-Example-Scripts folder to correct places
+	&& mv /powershell/PowerCLI-Example-Scripts/Modules/VMware.VMEncryption ~/.local/share/powershell/Modules/ \
+	&& mv /powershell/PowerCLI-Example-Scripts/Modules/VMFSIncrease ~/.local/share/powershell/Modules/ \
+	&& mv /powershell/PowerCLI-Example-Scripts/Modules/Vi-Module ~/.local/share/powershell/Modules/ \
+	&& chmod +x /powershell/PowerCLI-Example-Scripts/Scripts/modules.sh \
+	&& /powershell/PowerCLI-Example-Scripts/Scripts/modules.sh  
 
 CMD ["powershell"]


### PR DESCRIPTION
Reduce the image from 610MB to 555MB with best practice

See https://hackernoon.com/tips-to-reduce-docker-image-sizes-876095da3b34

If you change PowerCLI_Core.zip and master.zip to PowerCLI_Core.tar.gz and marster.tar.gz, reduce the script by removing rm lines (ADD command extract auto tar.gz)