### PR TITLE
Fix versions of dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM photon
+FROM photon:3.0
   
 LABEL authors="renoufa@vmware.com,jaker@vmware.com"
 
@@ -9,13 +9,15 @@ WORKDIR /root
 # Set terminal. If we don't do this, weird readline things happen.
 RUN echo "/usr/bin/pwsh" >> /etc/shells && \
     echo "/bin/pwsh" >> /etc/shells && \
-    tdnf install -y powershell unzip && \
+    tdnf install -y powershell-6.2.3-1.ph3 unzip && \
     pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted" && \
-    pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.PowerCLI,PowerNSX,PowervRA" && \
-    curl -o ./PowerCLI-Example-Scripts.zip -J -L https://github.com/vmware/PowerCLI-Example-Scripts/archive/master.zip && \
+    pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.PowerCLI -RequiredVersion 11.5.0.14912921" && \
+    pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module PowerNSX -RequiredVersion 3.0.1174" && \
+    pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module PowervRA -RequiredVersion 3.6.0" && \
+    curl -o ./PowerCLI-Example-Scripts.zip -J -L https://github.com/vmware/PowerCLI-Example-Scripts/archive/03272c1d2db26a525b31c930e3bf3d20d34468e0.zip && \
     unzip PowerCLI-Example-Scripts.zip && \
     rm -f PowerCLI-Example-Scripts.zip && \
-    mv ./PowerCLI-Example-Scripts-master ./PowerCLI-Example-Scripts && \
+    mv ./PowerCLI-Example-Scripts-* ./PowerCLI-Example-Scripts && \
     mv ./PowerCLI-Example-Scripts/Modules/* /usr/lib/powershell/Modules/ && \
     find / -name "net45" | xargs rm -rf && \
     tdnf erase -y unzip && \


### PR DESCRIPTION
Based on the latest available versions of modules and dependencies fix their version to:
photon 3.0
Powershell 6.2.3
PowerCLI 11.5.0
PowerNSX 3.0.1174
PowervRA 3.6.0
The example scripts 03272c1d2db26a525b31c930e3bf3d20d34468e0 (latest commit from master)

This is needed so that we can have reproducible builds over time, and not unexpectedly pick up a new version of some those dependencies