### PR TITLE
Change base microsoft/powershell:lts-alpine-3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,23 @@
-FROM photon:3.0
-  
+FROM mcr.microsoft.com/powershell:lts-alpine-3.10
+
 LABEL authors="renoufa@vmware.com,jaker@vmware.com"
 
-ENV TERM linux
+# Set terminal. If we don't do this, weird readline things happen.
+# ENV TERM linux
 
 WORKDIR /root
 
-# Set terminal. If we don't do this, weird readline things happen.
 RUN echo "/usr/bin/pwsh" >> /etc/shells && \
     echo "/bin/pwsh" >> /etc/shells && \
-    tdnf install -y powershell-6.2.3-1.ph3 unzip && \
     pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted" && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.PowerCLI -RequiredVersion 11.5.0.14912921" && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module PowerNSX -RequiredVersion 3.0.1174" && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module PowervRA -RequiredVersion 3.6.0" && \
-    curl -o ./PowerCLI-Example-Scripts.zip -J -L https://github.com/vmware/PowerCLI-Example-Scripts/archive/03272c1d2db26a525b31c930e3bf3d20d34468e0.zip && \
+    wget -O ./PowerCLI-Example-Scripts.zip https://github.com/vmware/PowerCLI-Example-Scripts/archive/03272c1d2db26a525b31c930e3bf3d20d34468e0.zip && \
     unzip PowerCLI-Example-Scripts.zip && \
     rm -f PowerCLI-Example-Scripts.zip && \
     mv ./PowerCLI-Example-Scripts-* ./PowerCLI-Example-Scripts && \
-    mv ./PowerCLI-Example-Scripts/Modules/* /usr/lib/powershell/Modules/ && \
-    find / -name "net45" | xargs rm -rf && \
-    tdnf erase -y unzip && \
-    tdnf clean all
+    mv ./PowerCLI-Example-Scripts/Modules/* /opt/microsoft/powershell/7-lts/Modules/ && \
+    find . -name "net45" | xargs rm -rf
 
-
-CMD ["/bin/pwsh"]
+# CMD ["/bin/pwsh"]


### PR DESCRIPTION
This image has not been updated for quite a while. I recommend switching the base image (FROM tag) to use the microsoft/powershell images. I am not sure if that will count as an "official base image" (such that it won't trigger automatically when they release a new version) or not. Ideally, every time Microsoft releases an updated powershell core image, this would be rebuilt. I am not sure if there is any benefit in doing so, but Microsoft has a *bunch* of tags for different OS's, which also makes it easy to produce the same for powerclicore. 