### PR TITLE
Updates PowerShell to 7.0 and PowerCLI to 12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ WORKDIR /root
 # Set terminal. If we don't do this, weird readline things happen.
 RUN echo "/usr/bin/pwsh" >> /etc/shells && \
     echo "/bin/pwsh" >> /etc/shells && \
-    tdnf install -y powershell-6.2.3-1.ph3 unzip && \
+    tdnf install -y powershell-7.0.0-1.ph3 unzip && \
     pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted" && \
-    pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.PowerCLI -RequiredVersion 11.5.0.14912921" && \
+    pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.PowerCLI -RequiredVersion 12.0.0.15947286" && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module PowerNSX -RequiredVersion 3.0.1174" && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module PowervRA -RequiredVersion 3.6.0" && \
     curl -o ./PowerCLI-Example-Scripts.zip -J -L https://github.com/vmware/PowerCLI-Example-Scripts/archive/03272c1d2db26a525b31c930e3bf3d20d34468e0.zip && \


### PR DESCRIPTION
Updates PowerShell version to 7.0.0-1
Updates PowerCLI version to latest released 12.0
Testing done:

```
docker build -t powerclicore .
docker run -it powerclicore
PS /root> $PsVersionTable

Name                           Value
----                           -----
PSVersion                      7.0.0
PSEdition                      Core
GitCommitId                    7.0.0
OS                             Linux 4.19.76-linuxkit #1 SMP Fri Apr 3 15:53:26 UTC 2020
Platform                       Unix
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0

PS /root> Get-Module -Name VMware.PowerCLI -ListAvailable | Select Name,Version

Name            Version
----            -------
VMware.PowerCLI 12.0.0.15947286
PS /root> connect-viserver

PS /root> get-vm

Name                 PowerState Num CPUs MemoryGB
----                 ---------- -------- --------
Auto-TestRunner-Ubu… PoweredOn  2        6.000
```