### PR TITLE
Disable progress bar by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,11 @@ RUN echo "/usr/bin/pwsh" >> /etc/shells && \
     mv ./PowerCLI-Example-Scripts-* ./PowerCLI-Example-Scripts && \
     mv ./PowerCLI-Example-Scripts/Modules/* /usr/lib/powershell/Modules/ && \
     find / -name "net45" | xargs rm -rf && \
+    echo '$ProgressPreference = "SilentlyContinue"' > /root/.config/powershell/Microsoft.PowerShell_profile.ps1 && \
     tdnf erase -y unzip && \
     tdnf clean all
+
+
 
 
 CMD ["/bin/pwsh"]


### PR DESCRIPTION
PowerShell progress bar has issues in the Photon OS base container reported in https://stackoverflow.com/questions/60065251/error-running-powercli-from-docker-image-on-gitlab-ci-cd/66795047#66795047
To work around the issues I disable the progress bar setting the `ProgressPreference` to `SilentlyContinue` in the PowerShell profile file.

Testing done:
```powershell
Get-Vm wcp-esx3 | New-Snapshot -Name 'test'

Name                 Description                    PowerState
----                 -----------                    ----------
test                                                 PoweredOff

```