### PR TITLE
Update Dockerfile to remove powershell archive file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN echo "/usr/bin/pwsh" >> /etc/shells && \
     tdnf install -y wget tar icu powershell git unzip && \
     wget https://github.com/PowerShell/PowerShell/releases/download/v7.1.1/powershell-7.1.1-linux-x64.tar.gz && \
     tar -xvf /root/powershell-7.1.1-linux-x64.tar.gz -C /usr/lib/powershell && \
+    rm -f /root/powershell-7.1.1-linux-x64.tar.gz && \
     rm /usr/lib/powershell/libssl.so.1.0.0 && \
     rm /usr/lib/powershell/libcrypto.so.1.0.0 && \
     ln -s /usr/lib/libssl.so.1.1 /usr/lib/powershell/libssl.so.1.0.0 && \


### PR DESCRIPTION
The size of the container image can be reduced by deleting unnecessary archive file.
```
$ podman run --rm origin ls powershell-7.1.1-linux-x64.tar.gz
powershell-7.1.1-linux-x64.tar.gz
$ podman run --rm fixed ls powershell-7.1.1-linux-x64.tar.gz
ls: powershell-7.1.1-linux-x64.tar.gz: No such file or directory
$ buildah images
REPOSITORY                                TAG                                    IMAGE ID       CREATED          SIZE
localhost/fixed                           latest                                 d5095a9aeea8   30 seconds ago   638 MB
localhost/origin                          latest                                 da7ed5e0ab2c   18 minutes ago   706 MB
```
Signed-off-by: Shion Tanaka <shtanaka@redhat.com>