### PR TITLE
Update powershell version. Set TERM to linux-basic.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,18 @@
 FROM photon:3.0
-  
+
 LABEL authors="renoufa@vmware.com,jaker@vmware.com,dmilov@vmware.com"
 
-ENV TERM linux
+ENV TERM linux-basic
 
 WORKDIR /root
 
 # Set terminal. If we don't do this, weird readline things happen.
 RUN echo "/usr/bin/pwsh" >> /etc/shells && \
     echo "/bin/pwsh" >> /etc/shells && \
-    tdnf install -y wget tar icu powershell git unzip && \
-    wget https://github.com/PowerShell/PowerShell/releases/download/v7.1.1/powershell-7.1.1-linux-x64.tar.gz && \
-    tar -xvf /root/powershell-7.1.1-linux-x64.tar.gz -C /usr/lib/powershell && \
-    rm -f /root/powershell-7.1.1-linux-x64.tar.gz && \
-    rm /usr/lib/powershell/libssl.so.1.0.0 && \
-    rm /usr/lib/powershell/libcrypto.so.1.0.0 && \
-    ln -s /usr/lib/libssl.so.1.1 /usr/lib/powershell/libssl.so.1.0.0 && \
-    ln -s /usr/lib/libcrypto.so.1.1 /usr/lib/powershell/libcrypto.so.1.0.0 && \
-    pwsh -c "Enable-ExperimentalFeature PSDesiredStateConfiguration.InvokeDscResource" && \
+    tdnf install -y wget tar icu powershell-7.1.2-2.ph3 git unzip && \
     pwsh -c "Set-PSRepository -Name PSGallery -InstallationPolicy Trusted" && \
+    pwsh -c "Install-Module -Name PSDesiredStateConfiguration" && \
+    pwsh -c "Enable-ExperimentalFeature PSDesiredStateConfiguration.InvokeDscResource" && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.PowerCLI" && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.vSphereDSC" && \
     pwsh -c "\$ProgressPreference = \"SilentlyContinue\"; Install-Module VMware.PSDesiredStateConfiguration" && \


### PR DESCRIPTION
Fixes issue #58.

The `TERM linux` create terminal with small witdh which prevents displaying hashtable formatted by `Out-String` cmdlet. The issue details are described in #58.


Update PowerShell version to 7.1.2-2, the latest available Photon OS PowerShell package. It is not necessary to install powershell manually now because the experimental feature for `Invoke-DSCResource` is available on 7.1.2-2.

Signed-off-by: Dimitar Milov <dmilov@vmware.com>